### PR TITLE
A+C: Add Renée French for numerical gopher

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -18,6 +18,7 @@ James Bell <james@stellentus.com>
 Jeff Juozapaitis <jjjuozap@email.arizona.edu>
 Jonathan J Lawlor <jonathan.lawlor@gmail.com>
 Pontus Melke <pontusmelke@gmail.com>
+Renée French
 Sebastien Binet <seb.binet@gmail.com>
 Steve McCoy <mccoyst@gmail.com>
 The University of Adelaide

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -25,6 +25,7 @@ James Bell <james@stellentus.com>
 Jeff Juozapaitis <jjjuozap@email.arizona.edu>
 Jonathan J Lawlor <jonathan.lawlor@gmail.com>
 Pontus Melke <pontusmelke@gmail.com>
+Renée French
 Sebastien Binet <seb.binet@gmail.com>
 Steve McCoy <mccoyst@gmail.com>
 Vladimír Chalupecký <vladimir.chalupecky@gmail.com>


### PR DESCRIPTION
@gonum/developers

Renée French did the numerical gopher in square brackets as a
commission, so it is in that regard distinct from the Go gopher. This
A+C addition is to reflect the fact that she put work into the gonum
project aside from her CC artwork.

The email address field of the A+C lines is empty since she has no
publically visible textual representation of her email address, and I
negelected to ask if it was OK to publish her email when asking if she
was OK having her name in the A+C.